### PR TITLE
Add resumable option and pass it to bucket.upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ An object containing additional metadata to set. Default `{}`.
 
 Concurrent uploads to run. Default `20`.
 
+#### `options.resumable` (Boolean)
+
+Defines if uploads should be resumable or not. Default `true`.
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 

--- a/tasks/services/gcs.js
+++ b/tasks/services/gcs.js
@@ -15,7 +15,8 @@ module.exports = function(grunt) {
       gzip: true,
       headers: {},
       metadata: {},
-      concurrent: 20
+      concurrent: 20,
+      resumable: true
     });
 
     // Checks
@@ -89,7 +90,8 @@ module.exports = function(grunt) {
         bucket.upload(file.src, {
           destination: file.dest,
           gzip: options.gzip,
-          metadata
+          metadata,
+          resumable: options.resumable
         }, (err, file) => {
           if (err) {
             grunt.fail.warn(err);


### PR DESCRIPTION
About the resumable option: https://cloud.google.com/nodejs/docs/reference/storage/2.3.x/Bucket#upload

Motivation: Due to some potential race-conditions that parallel calls to this task
can cause (eg: build pipelines optimised to deploy assets in parallel
and save some time), disabling `resumable` is a way to mitigate those, as we can see
here in this [issue report](https://github.com/googleapis/google-cloud-node/issues/1154#issuecomment-192703812).