### PR TITLE
Support google-cloud's auto retry

### DIFF
--- a/tasks/services/gcs.js
+++ b/tasks/services/gcs.js
@@ -28,7 +28,9 @@ module.exports = function(grunt) {
     }
 
     let storageOptions = {
-      projectId: options.project
+      projectId: options.project,
+      autoRetry: options.autoRetry,
+      maxRetries: options.maxRetries
     };
 
     // Setup authentication


### PR DESCRIPTION
Hello,

We want to use this package in our build in order to upload artifacts to google cloud. But we need a retry mechanism.
Why?
We currently use [grunt-gcloud](https://github.com/ubilabs/grunt-gcloud) and sometimes the upload process fails with 
`Warning: Backend Error Use --force to continue.`. This package does not have any retry mechanism.

We found out this package is wrapping google's package for uploading to gcloud, and [that package accepts autoRetry](https://github.com/googleapis/nodejs-storage/blob/862fb16db2990c958c0097252a44c775431a7b3f/src/storage.ts#L50).

Let's expose this outside? :)